### PR TITLE
GHC 7.4 support

### DIFF
--- a/sandi.cabal
+++ b/sandi.cabal
@@ -24,10 +24,9 @@ library
     ghc-options: -Wall
     cc-options: -Wall -Wextra
     build-depends:
-        base ==4.6.*,
-        bytestring ==0.10.*,
-        conduit ==1.0.*,
-        resourcet ==0.4.*
+        base >=4.5 && < 4.7,
+        bytestring >=0.9 && < 0.11,
+        conduit ==1.0.*
     exposed-modules:
             Codec.Binary.Base16
             Codec.Binary.Base32


### PR DESCRIPTION
I tried compiling on GHC 7.4.2, but the cabal file had restrictions on bytestring and base. Once I relaxed the constraints, the code compiled and ran just fine. (It also seems like resourcet was not a needed dependency, so I removed it.)

As a separate point, I was curious how sandi would compare performance-wise to base64-bytestring and base64-conduit. I put together a [small benchmark](https://gist.github.com/snoyberg/5075429). I didn't spend much time on it, so there may be flaws, but it seems to indicate that all three libraries are in the same ballpark of performance, with base64-bytestring being faster on smaller datasets and sandi faster on larger datasets.

Nice package!
