### PR TITLE
allow base-4.8

### DIFF
--- a/sandi.cabal
+++ b/sandi.cabal
@@ -28,7 +28,7 @@ library
     ghc-options: -Wall
     cc-options: -fPIC -Wall -Wextra
     build-depends:
-        base ==4.7.*,
+        base >=4.7 && <4.9,
         bytestring ==0.10.*
     exposed-modules:
         Codec.Binary.Base16


### PR DESCRIPTION
This PR relaxes the upper bound on base to include versions 4.8.*.

Further it would be nice if the upper bound on base for released sandi-0.3.3 could be relaxed on Hackage.