### PR TITLE
Fix cabal categories

### DIFF
--- a/sandi.cabal
+++ b/sandi.cabal
@@ -8,7 +8,7 @@ author: Magnus Therning
 maintainer: magnus@therning.org
 homepage: http://hackage.haskell.org/package/sandi
 copyright: Magnus Therning, 2012
-category: Codec Conduit
+category: Codec, Conduit
 synopsis: Data encoding library
 description: Reasonably fast data encoding library.
 extra-source-files: csrc/*.h


### PR DESCRIPTION
This places `sandi` in the existing categories `Codec` and `Conduit`, instead of the otherwise-unoccupied category `Codec Conduit`.
